### PR TITLE
Wait for 20 seconds for htcondor-ce to finish starting up

### DIFF
--- a/10-htcondor-ce.conf
+++ b/10-htcondor-ce.conf
@@ -1,5 +1,5 @@
 [program:htcondor-ce]
 command=/usr/share/condor-ce/condor_ce_startup
 autorestart=true
-startsecs=20.0
+startsecs=20
 

--- a/10-htcondor-ce.conf
+++ b/10-htcondor-ce.conf
@@ -1,3 +1,5 @@
 [program:htcondor-ce]
 command=/usr/share/condor-ce/condor_ce_startup
 autorestart=true
+startsecs=20.0
+


### PR DESCRIPTION
If htcondor-ce can't stay up for 20 seconds, supervisord will raise an
error instead of restarting it.  This is an increase from the default
of 1 second.  Sometimes it takes longer for condor-ce to crash...