### PR TITLE
Disable errexit and xtrace during development

### DIFF
--- a/25-hosted-ce-setup.sh
+++ b/25-hosted-ce-setup.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-set -xe
-
 #kubernetes configmaps arent writeable
 stat /tmp/99-local.ini
 if [[ $? -eq 0 ]]; then
@@ -45,5 +43,3 @@ fi
 echo ">>>>> YOUR CERTIFICATE INFORMATION IS:"
 openssl x509 -in $hostcert_path -noout -text
 echo "><><><><><><><><><><><><><><><><><><><"
-
-set +xe

--- a/30-remote-site-setup.sh
+++ b/30-remote-site-setup.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-set -xe
-
 . /usr/local/bin/foreach_bosco_endpoint.sh
 
 BOSCO_KEY=/etc/osg/bosco.key
@@ -66,5 +64,3 @@ GIT_SSH_KEY=/etc/osg/git.key
 unset GIT_SSH_COMMAND
 
 /usr/local/bin/bosco-cluster-remote-hosts.sh
-
-set +xe


### PR DESCRIPTION
Broken scripts cause the container to die and because of issues with
'docker/kubectl logs', it's difficult to figure out why...