### PR TITLE
Fix fetch-crl and gratia probes cron

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,7 @@ COPY 99-container.conf /usr/share/condor-ce/config.d/
 # TODO: Drop this after implementing non-root Gratia probes
 # https://opensciencegrid.atlassian.net/browse/SOFTWARE-3975
 RUN chmod 1777 /var/lib/gratia/tmp
+RUN touch /var/lock/subsys/gratia-probes-cron
 
 # can be dropped when provided by upstream htcondor-ce packaging
 RUN mkdir -p /etc/condor-ce/bosco_override

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,7 @@ COPY foreach_bosco_endpoint.sh     /usr/local/bin/foreach_bosco_endpoint.sh
 
 # do the bad thing of overwriting the existing cron job for fetch-crl
 ADD fetch-crl /etc/cron.d/fetch-crl
+RUN chmod 644 /etc/cron.d/fetch-crl
 
 # Include script to drain the CE and upload accounting data to prepare for container teardown
 COPY drain-ce.sh /usr/local/bin/


### PR DESCRIPTION
-Need correct file mode for fetch-crl cron

-Touching `/var/lock/subsys/gratia-probes-cron` prevents cron_check from failing

```
Gratia probes cron services is disabled, to start use 
 service gratia-probes-cron start
5:47
	#checks if the service is enabled 
	if not os.path.exists("/var/lock/subsys/gratia-probes-cron"):
		log("Gratia probes cron services is disabled, to start use \n service gratia-probes-cron start")
		sys.exit(1)
```