### PR TITLE
Dump host cert and key into logs to be saved for subsequent use

### DIFF
--- a/25-hosted-ce-setup.sh
+++ b/25-hosted-ce-setup.sh
@@ -55,3 +55,8 @@ fi
 echo ">>>>> YOUR CERTIFICATE INFORMATION IS:"
 openssl x509 -in $hostcert_path -noout -text
 echo "><><><><><><><><><><><><><><><><><><><"
+
+echo ">>>>> YOUR HOST CERT AND KEY ARE:"
+cat $hostcert_path
+cat $hostkey_path
+echo "><><><><><><><><><><><><><><><><><><><"


### PR DESCRIPTION
Because of Let's Encrypt request limits (something like max ~5 requests per host in a short time frame before being banned for a week), we've added a way for an operator to save the host cert/key pair across instances. However, operators can't get the cert/key pair unless they're k8s admins of the cluster they're deploying to. 

Dumping the file contents will allow the operators to view them from the SLATE instance logs...but it still doesn't feel great. Thoughts?