### PR TITLE
Populate SSH config since GIT_SSH_COMMAND is only available in git 2.3+

### DIFF
--- a/30-remote-site-setup.sh
+++ b/30-remote-site-setup.sh
@@ -62,11 +62,9 @@ echo "IdentityFile ${BOSCO_KEY}" > $root_ssh_dir/config
 echo $REMOTE_HOST_KEY >> $root_ssh_dir/known_hosts
 
 # Populate the bosco override dir from a Git repo
-GIT_SSH_KEY=/etc/osg/git.key
-[[ -f $GIT_SSH_KEY ]] && export GIT_SSH_COMMAND="ssh -i $GIT_SSH_KEY"
 if [[ -n $BOSCO_GIT_ENDPOINT && -n $BOSCO_DIRECTORY ]]; then
     OVERRIDE_DIR=/etc/condor-ce/bosco_override
-    /usr/local/bin/bosco-override-setup.sh "$BOSCO_GIT_ENDPOINT" "$BOSCO_DIRECTORY"
+    /usr/local/bin/bosco-override-setup.sh "$BOSCO_GIT_ENDPOINT" "$BOSCO_DIRECTORY" /etc/osg/git.key
 fi
 unset GIT_SSH_COMMAND
 

--- a/30-remote-site-setup.sh
+++ b/30-remote-site-setup.sh
@@ -35,37 +35,6 @@ EOF
   ls -l "$ssh_dir"
 }
 
-# Populate the bosco override dir from a Git repo
-# Expected Git repo layout:
-#     RESOURCE_NAME_1/
-#         bosco_override/
-#         ...
-#     RESOURCE_NAME_2/
-#         bosco_override/
-#         ...
-#     ...
-function bosco_override_setup {
-    GIT_ENDPOINT=$1
-    RESOURCE_NAME=$2
-
-    # Set up config for SSH endpoints
-    if [[ $GIT_ENDPOINT =~ ^[A-Za-z0-9_-]+@([^:]+): ]]; then
-        ssh-keyscan "${BASH_REMATCH[1]}" >> ~/.ssh/known_hosts
-    fi
-
-    REPO_DIR=$(mktemp -d)
-    OVERRIDE_DIR=/etc/condor-ce/bosco_override/
-
-    git clone --depth=1 $GIT_ENDPOINT $REPO_DIR
-
-    # Bosco override dirs are expected in the following location in the git repo:
-    #   <RESOURCE NAME>/bosco_override/
-    RESOURCE_DIR="$REPO_DIR/$RESOURCE_NAME/"
-    [[ -d $RESOURCE_DIR ]] || errexit "Could not find $RESOURCE_NAME/ under $GIT_ENDPOINT"
-    rsync -a "$RESOURCE_DIR/bosco_override/"  $OVERRIDE_DIR
-}
-
-
 # Install the WN client, CAs, and CRLs on the remote host
 # Store logs in /var/log/condor-ce/ to simplify serving logs via Kubernetes
 setup_endpoints_ini () {
@@ -97,7 +66,7 @@ GIT_SSH_KEY=/etc/osg/git.key
 [[ -f $GIT_SSH_KEY ]] && export GIT_SSH_COMMAND="ssh -i $GIT_SSH_KEY"
 if [[ -n $BOSCO_GIT_ENDPOINT && -n $BOSCO_DIRECTORY ]]; then
     OVERRIDE_DIR=/etc/condor-ce/bosco_override
-    bosco_override_setup "$BOSCO_GIT_ENDPOINT" "$BOSCO_DIRECTORY"
+    /usr/local/bin/bosco-override-setup.sh "$BOSCO_GIT_ENDPOINT" "$BOSCO_DIRECTORY"
 fi
 unset GIT_SSH_COMMAND
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,6 +46,7 @@ RUN patch -d / -p0 < /tmp/ssh_q.patch
 #         bosco_override/
 #         ...
 #     ...
+COPY bosco-override-setup.sh /usr/local/bin
 
 # Manage HTCondor-CE with supervisor
 COPY 10-htcondor-ce.conf /etc/supervisord.d/

--- a/bosco-override-setup.sh
+++ b/bosco-override-setup.sh
@@ -15,14 +15,25 @@ function errexit {
     exit 1
 }
 
-[[ $# -eq 2 ]] || errexit "Usage: bosco-override-setup.sh <GIT ENDPOINT> <RESOURCE NAME>"
+[[ $# -ge 2 ]] || errexit "Usage: bosco-override-setup.sh <GIT ENDPOINT> <RESOURCE NAME> [<GIT SSH KEY>]"
 
 GIT_ENDPOINT=$1
 RESOURCE_NAME=$2
+GIT_SSH_KEY=$3
 
 # pre-scan the Git repo's host key
-if [[ $GIT_ENDPOINT =~ ^[A-Za-z0-9_-]+@([^:]+): ]]; then
-    ssh-keyscan "${BASH_REMATCH[1]}" >> ~/.ssh/known_hosts
+if [[ $GIT_ENDPOINT =~ ^([A-Za-z0-9_-]+)@([^:]+): ]]; then
+    GIT_USER="${BASH_REMATCH[1]}"
+    GIT_HOST="${BASH_REMATCH[2]}"
+    ssh-keyscan "${BASH_REMATCH[2]}" >> ~/.ssh/known_hosts
+    if [[ -f "$GIT_SSH_KEY" ]]; then
+        cat <<EOF >> ~/.ssh/config
+
+Host $GIT_HOST
+User $GIT_USER
+IdentityFile $GIT_SSH_KEY
+EOF
+    fi
 fi
 
 REPO_DIR=$(mktemp -d)

--- a/bosco-override-setup.sh
+++ b/bosco-override-setup.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# Populate the bosco override dir from a Git repo
+# Expected Git repo layout:
+#     RESOURCE_NAME_1/
+#         bosco_override/
+#         ...
+#     RESOURCE_NAME_2/
+#         bosco_override/
+#         ...
+#     ...
+
+function errexit {
+    echo "$1" >&2
+    exit 1
+}
+
+[[ $# -eq 2 ]] || errexit "Usage: bosco-override-setup.sh <GIT ENDPOINT> <RESOURCE NAME>"
+
+GIT_ENDPOINT=$1
+RESOURCE_NAME=$2
+
+# pre-scan the Git repo's host key
+if [[ $GIT_ENDPOINT =~ ^[A-Za-z0-9_-]+@([^:]+): ]]; then
+    ssh-keyscan "${BASH_REMATCH[1]}" >> ~/.ssh/known_hosts
+fi
+
+REPO_DIR=$(mktemp -d)
+OVERRIDE_DIR=/etc/condor-ce/bosco_override/
+
+git clone --depth=1 $GIT_ENDPOINT $REPO_DIR
+
+# Bosco override dirs are expected in the following location in the git repo:
+#   <RESOURCE NAME>/bosco_override/
+RESOURCE_DIR="$REPO_DIR/$RESOURCE_NAME/"
+[[ -d $RESOURCE_DIR ]] || errexit "Could not find $RESOURCE_NAME/ under $GIT_ENDPOINT"
+rsync -az "$RESOURCE_DIR/bosco_override/"  $OVERRIDE_DIR


### PR DESCRIPTION
And CentOS 7 only has git 1.8 :(. Also revert back to the separate script since we have to pass along the key information to the git SSH setup code anyway.