### PR TITLE
Unlike the rest of the ProbeConfig, the lock file is not camelcase

### DIFF
--- a/configure-nonroot-gratia.py
+++ b/configure-nonroot-gratia.py
@@ -27,7 +27,7 @@ def main():
 
     probe_config = probe_et.getroot()
 
-    probe_config.attrib['LockFile'] = '/var/lock/condor-ce/gratia.lock'
+    probe_config.attrib['Lockfile'] = '/var/lock/condor-ce/gratia.lock'
     probe_config.attrib['WorkingFolder'] = '/var/lib/condor-ce/'
     probe_config.attrib['LogFolder'] = '/var/log/condor-ce/'
 


### PR DESCRIPTION
https://github.com/opensciencegrid/gratia-probe/blob/10d8989b7cdba8076643a9d02fb33bfbf20d5d1b/common/gratia/common/GratiaWrapper.py#L87