### PR TITLE
SSH doesn't appear to like hashed hostkeys in known_hosts

### DIFF
--- a/30-remote-site-setup.sh
+++ b/30-remote-site-setup.sh
@@ -83,7 +83,7 @@ else
     remote_port=22
 fi
 
-REMOTE_HOST_KEY=`ssh-keyscan -p "$remote_port" -H "$remote_fqdn"`
+REMOTE_HOST_KEY=`ssh-keyscan -p "$remote_port" "$remote_fqdn"`
 [[ -n $REMOTE_HOST_KEY ]] || errexit "Failed to determine host key for $remote_fqdn:$remote_port"
 
 # Set the appropriate SSH key for bosco_cluster commands


### PR DESCRIPTION
`ssh-keyscan` documentation has misled me for the last time

```
     -H      Hash all hostnames and addresses in the output.  Hashed names may be used normally by ssh(1)
             and sshd(8), but they do not reveal identifying information should the file's contents be dis‐
             closed.
```