### PR TITLE
Fix missed reference to $REMOTE_HOST

### DIFF
--- a/30-remote-site-setup.sh
+++ b/30-remote-site-setup.sh
@@ -150,7 +150,7 @@ for ruser in $users; do
 
     # Copy over environment files to allow for dynamic WN variables (SOFTWARE-4117)
     rsync -av /var/lib/osg/osg-*job-environment.conf \
-          "${ruser}@$REMOTE_HOST:$REMOTE_BOSCO_DIR/glite/etc"
+          "${ruser}@$remote_fqdn:$REMOTE_BOSCO_DIR/glite/etc"
 done
 
 if [[ $cvmfs_wn_client == 'no' ]]; then


### PR DESCRIPTION
This caused issues for sites with non-default SSH ports:

rsync: mkdir "/home/users/svc-osg01/14022:bosco_slate/glite/etc" failed: No such file or directory (2)