### PR TITLE
Allow use of Let's Encrypt staging server (SOFTWARE-4278)

### DIFF
--- a/25-hosted-ce-setup.sh
+++ b/25-hosted-ce-setup.sh
@@ -34,6 +34,9 @@ hostkey_path=/etc/grid-security/hostkey.pem
 hostcsr_path=/etc/grid-security/host.req
 
 certbot_opts="--noninteractive --agree-tos --standalone --email $CE_CONTACT -d $CE_HOSTNAME"
+
+[[ $LE_STAGING == "true" ]] && certbot_opts="$certbot_opts --dry-run"
+
 if [ ! -f $hostcert_path ] || [ ! -f $hostkey_path ]; then
     echo "Establishing Let's Encrypt certificate.."
     if [ -f $hostkey_path ]; then


### PR DESCRIPTION
From https://letsencrypt.org/docs/staging-environment/:

```
If you’re using Certbot, you can use our staging environment with the --dry-run flag. 
```

Corresponding PR will be submitted for the SLATE app to set `LE_STAGING` appropriately