### PR TITLE
Only fetch the remote OS version once (SOFTWARE-4328)

### DIFF
--- a/30-remote-site-setup.sh
+++ b/30-remote-site-setup.sh
@@ -165,7 +165,7 @@ done
 ###################
 
 # We have to pick a user for SSH, may as well be the first one
-remote_os_info=$(fetch_remote_os_info "$(echo $users | head -n1)" "$remote_fqdn")
+remote_os_info=$(fetch_remote_os_info "$(printf "%s\n" $users | head -n1)" "$remote_fqdn")
 remote_os_ver=$(echo "$remote_os_info" | awk -F '=' '/^VERSION_ID/ {print $2}' | tr -d '"')
 
 for ruser in $users; do
@@ -186,4 +186,3 @@ else
 fi
 
 set $olde
-

--- a/30-remote-site-setup.sh
+++ b/30-remote-site-setup.sh
@@ -29,7 +29,7 @@ function debug_file_contents {
 function fetch_remote_os_info {
     ruser=$1
     rhost=$2
-    ssh -q -i $BOSCO_KEY "${ruser}@$rhost" "cat /etc/os-release"
+    ssh -q -i $BOSCO_KEY "$ruser@$rhost" "cat /etc/os-release"
 }
 
 setup_ssh_config () {

--- a/30-remote-site-setup.sh
+++ b/30-remote-site-setup.sh
@@ -165,7 +165,7 @@ done
 ###################
 
 # We have to pick a user for SSH, may as well be the first one
-remote_os_info=$(fetch_remote_os_info "${users%%[:blank:]*}" "$remote_fqdn")
+remote_os_info=$(fetch_remote_os_info "$(echo $users | head -n1)" "$remote_fqdn")
 remote_os_ver=$(echo "$remote_os_info" | awk -F '=' '/^VERSION_ID/ {print $2}' | tr -d '"')
 
 for ruser in $users; do


### PR DESCRIPTION
Also use `/etc/os-release` for better cross-platform support. `remote_os_info` and `remote_os_ver` are split into two different vars because we'll need to do some OS dist detection and I didn't want to cram too much into a single PR.

Should fix an issue that @efajardo is running into.