### PR TITLE
Use a relative remote WN dir

### DIFF
--- a/30-remote-site-setup.sh
+++ b/30-remote-site-setup.sh
@@ -77,7 +77,6 @@ EOF
 setup_endpoints_ini () {
     echo "Setting up endpoint.ini entry for ${ruser}@$remote_fqdn..."
     remote_os_major_ver=$1
-    remote_home_dir=$(ssh -q -i $BOSCO_KEY "${ruser}@$remote_fqdn" pwd)
     osg_ver=3.4
     if [[ $remote_os_major_ver -gt 6 ]]; then
         osg_ver=3.5
@@ -87,7 +86,7 @@ setup_endpoints_ini () {
 local_user = ${ruser}
 remote_host = $remote_fqdn
 remote_user = ${ruser}
-remote_dir = $remote_home_dir/bosco-osg-wn-client
+remote_dir = bosco-osg-wn-client
 upstream_url = https://repo.opensciencegrid.org/tarball-install/${osg_ver}/osg-wn-client-latest.el${remote_os_major_ver}.x86_64.tar.gz
 EOF
 }


### PR DESCRIPTION
Since detection of the remote home dir is prone to failure. This looks like it should work based off of https://github.com/opensciencegrid/hosted-ce-tools/blob/master/scripts/update-remote-wn-client#L162-L179