### PR TITLE
Enable xtrace when running bosco_cluster in debug mode

### DIFF
--- a/overrides/bosco_cluster
+++ b/overrides/bosco_cluster
@@ -775,6 +775,7 @@ while true; do
     esac
 done
 
+[[ $debug -eq 1 ]] && set -x
 
 ################################################################
 # The rest of the file covers the 'add' cluster functionality.


### PR DESCRIPTION
We execute `bosco_cluster` from `30-remote-site-setup.sh`. I'm tired of adding specific troubleshooting messages for each `bosco_cluster` issue we come across.