### PR TITLE
Fix backwards skip WN client cron logic

### DIFF
--- a/99-container.conf
+++ b/99-container.conf
@@ -14,7 +14,7 @@ SCHEDD_CRON_GRATIA_ARGS = -f /etc/gratia/htcondor-ce/ProbeConfig
 SCHEDD_CRON_GRATIA_PERIOD = 4h
 
 # Keep the remote WN client up-to-date
-if defined SKIP_WNCLIENT
+if ! defined SKIP_WNCLIENT
   SCHEDD_CRON_JOBLIST = $(SCHEDD_CRON_JOBLIST) WNCLIENT
   SCHEDD_CRON_WNCLIENT_MODE = Periodic
   SCHEDD_CRON_WNCLIENT_PERIOD = 12h


### PR DESCRIPTION
This isn't related to the issues you're seeing @efajardo but it's another bug that I noticed