### PR TITLE
Revert "Go directly to the OSG Yum repos instead of waiting for...

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,6 @@
 FROM opensciencegrid/software-base:fresh
 LABEL maintainer "OSG Software <help@opensciencegrid.org>"
 
-# Impatiently ignore the Yum mirrors
-RUN sed -i 's/\#baseurl/baseurl/; s/mirrorlist/\#mirrorlist/' \
-           /etc/yum.repos.d/osg-testing.repo
-
 RUN yum install -y --enablerepo=osg-testing \
                    --enablerepo=osg-upcoming-testing \
                    osg-ce-bosco \


### PR DESCRIPTION
...the  mirrors"

This reverts commit 5a7320aeed0573f60b477e7b073814a352c5dae1,
superseded by https://github.com/opensciencegrid/docker-software-base/pull/21

I'd prefer merging this first since the software-base merge will kick off a dispatch to the Hosted CE repo anyway.