### PR TITLE
Publish dev, testing, and release tags (SOFTWARE-4457) 

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -1,26 +1,44 @@
-name: dispatched build-docker-image
+name: Build and Push Docker image
 
 on:
   push:
-    branches:
-      - master
+    branches: [ SOFTWARE-4300.common-ce-base ]
   repository_dispatch:
     types:
       - dispatch-build
 
 jobs:
-  build:
+  make-date-tag:
     runs-on: ubuntu-latest
     if: startsWith(github.repository, 'opensciencegrid/')
+    outputs:
+      dtag: ${{ steps.mkdatetag.outputs.dtag }}
     steps:
-    - uses: actions/checkout@v2
-
     - name: make date tag
       id: mkdatetag
       run: echo "::set-output name=dtag::$(date +%Y%m%d-%H%M)"
 
-    - id: format-docker-repo
-      run: echo "::set-output name=repo-name::${GITHUB_REPOSITORY/opensciencegrid\/docker-/opensciencegrid/}"
+  build:
+    runs-on: ubuntu-latest
+    needs: [make-date-tag]
+    if: startsWith(github.repository, 'opensciencegrid/')
+    strategy:
+      fail-fast: False
+      matrix:
+        repo: ['development', 'testing', 'release']
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        ref: SOFTWARE-4300.common-ce-base
+
+    - id: generate-tag-list
+      env:
+        REPO: ${{ matrix.repo }}
+        TIMESTAMP: ${{ needs.make-date-tag.outputs.dtag }}
+      run: |
+        docker_repo=${GITHUB_REPOSITORY/opensciencegrid\/docker-/opensciencegrid/}
+        tag_list=$docker_repo:$REPO,$docker_repo:$REPO-$TIMESTAMP
+        echo "::set-output name=taglist::$tag_list"
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v1
@@ -35,5 +53,5 @@ jobs:
       uses: docker/build-push-action@v2.2.0
       with:
         push: true
-        tags: "${{ steps.format-docker-repo.outputs.repo-name }}:fresh,\
-          ${{ steps.format-docker-repo.outputs.repo-name }}:${{ steps.mkdatetag.outputs.dtag }}"
+        build-args: BASE_YUM_REPO=${{ matrix.repo }}
+        tags: "${{ steps.generate-tag-list.outputs.taglist }}"

--- a/.github/workflows/old-tagging-policy.yml
+++ b/.github/workflows/old-tagging-policy.yml
@@ -1,0 +1,39 @@
+name: Fresh image builds
+
+on:
+  push:
+    branches:
+      - master
+  repository_dispatch:
+    types:
+      - dispatch-build
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    if: startsWith(github.repository, 'opensciencegrid/')
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: make date tag
+      id: mkdatetag
+      run: echo "::set-output name=dtag::$(date +%Y%m%d-%H%M)"
+
+    - id: format-docker-repo
+      run: echo "::set-output name=repo-name::${GITHUB_REPOSITORY/opensciencegrid\/docker-/opensciencegrid/}"
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v1
+
+    - name: Log in to Docker Hub
+      uses: docker/login-action@v1
+      with:
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+
+    - name: Build and push Docker images
+      uses: docker/build-push-action@v2.2.0
+      with:
+        push: true
+        tags: "${{ steps.format-docker-repo.outputs.repo-name }}:fresh,\
+          ${{ steps.format-docker-repo.outputs.repo-name }}:${{ steps.mkdatetag.outputs.dtag }}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,14 @@
-FROM opensciencegrid/software-base:fresh
+ARGS BASE_YUM_REPO=release
+
+FROM opensciencegrid/software-base:$BASE_YUM_REPO
 LABEL maintainer "OSG Software <help@opensciencegrid.org>"
 
-RUN yum install -y --enablerepo=osg-testing \
-                   --enablerepo=osg-upcoming-testing \
+ARGS BASE_YUM_REPO=release
+
+RUN if [[ $BASE_YUM_REPO = release ]]; then \
+       yumrepo=osg-upcoming; else \
+       yumrepo=osg-upcoming-$BASE_YUM_REPO; fi && \
+    yum install -y --enablerepo=$yumrepo \
                    osg-ce-bosco \
                    # FIXME: avoid htcondor-ce-collector conflict
                    htcondor-ce \


### PR DESCRIPTION
Generates new development, testing, and release tags based off of https://github.com/opensciencegrid/docker-hosted-ce/tree/SOFTWARE-4300.common-ce-base

Moved the fresh tagging workflow to a new file that we can drop when we stop supporting `fresh` and `stable` tags.